### PR TITLE
removed continue and added args to make_bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Please send a pull request or issue if you have additional information about new
 Validation of bags has two possible options:
 
 The default behavior of `$ grabbags --validate` is to validate the bag by comparing the checksums of all files with the checksums contained in the manifest.
-Users can optionally use the flags `--validate --no--checksums`. This only validates the Oxsum of the bag, the number of files, and the proper files according to the bagit specification. Using the --no-checksums flag is equivalent to running `--validate --completeness-only`
+Users can optionally use the flags `--validate --no-checksums`. This only validates the Oxsum of the bag, the number of files, and the proper files according to the bagit specification. Using the --no-checksums flag is equivalent to running `--validate --completeness-only`
 
 ## Enhanced Logging
 Just as in bagit python, users can use the `--log (path to place log file)` flag to create a log when creating or validating bags. At the end of the output grabbags will display summary data about the numbers of bags created or validated (number of successes, number of failures and path to all failures).

--- a/grabbags/grabbags.py
+++ b/grabbags/grabbags.py
@@ -180,6 +180,7 @@ def _configure_logging(opts):
 def validate_bag(bag_dir, args):
     if not is_bag(bag_dir.path):
         LOGGER.warn(_("%s is not a bag. Skipped."), bag_dir.path)
+        return
 
     bag = bagit.Bag(bag_dir.path)
     # validate throws a BagError or BagValidationError
@@ -202,6 +203,7 @@ def validate_bag(bag_dir, args):
 def clean_bag(bag_dir):
     if not is_bag(bag_dir.path):
         LOGGER.warn(_("%s is not a bag. Not cleaning."), bag_dir.path)
+        return
 
     bag = bagit.Bag(bag_dir.path)
     if bag.compare_manifests_with_fs()[1]:
@@ -216,6 +218,7 @@ def clean_bag(bag_dir):
 def make_bag(bag_dir, args):
     if is_bag(bag_dir.path):
         LOGGER.warn(_("%s is already a bag. Skipped."), bag_dir.path)
+        return
 
     if args.no_system_files is True:
         LOGGER.info(_("Cleaning %s of system files"), bag_dir.path)

--- a/grabbags/grabbags.py
+++ b/grabbags/grabbags.py
@@ -180,7 +180,6 @@ def _configure_logging(opts):
 def validate_bag(bag_dir, args):
     if not is_bag(bag_dir.path):
         LOGGER.warn(_("%s is not a bag. Skipped."), bag_dir.path)
-        # continue
 
     bag = bagit.Bag(bag_dir.path)
     # validate throws a BagError or BagValidationError
@@ -203,7 +202,6 @@ def validate_bag(bag_dir, args):
 def clean_bag(bag_dir):
     if not is_bag(bag_dir.path):
         LOGGER.warn(_("%s is not a bag. Not cleaning."), bag_dir.path)
-        # continue
 
     bag = bagit.Bag(bag_dir.path)
     if bag.compare_manifests_with_fs()[1]:
@@ -218,7 +216,6 @@ def clean_bag(bag_dir):
 def make_bag(bag_dir, args):
     if is_bag(bag_dir.path):
         LOGGER.warn(_("%s is already a bag. Skipped."), bag_dir.path)
-        # continue
 
     if args.no_system_files is True:
         LOGGER.info(_("Cleaning %s of system files"), bag_dir.path)

--- a/grabbags/grabbags.py
+++ b/grabbags/grabbags.py
@@ -180,7 +180,7 @@ def _configure_logging(opts):
 def validate_bag(bag_dir, args):
     if not is_bag(bag_dir.path):
         LOGGER.warn(_("%s is not a bag. Skipped."), bag_dir.path)
-        continue
+        # continue
 
     bag = bagit.Bag(bag_dir.path)
     # validate throws a BagError or BagValidationError
@@ -203,7 +203,7 @@ def validate_bag(bag_dir, args):
 def clean_bag(bag_dir):
     if not is_bag(bag_dir.path):
         LOGGER.warn(_("%s is not a bag. Not cleaning."), bag_dir.path)
-        continue
+        # continue
 
     bag = bagit.Bag(bag_dir.path)
     if bag.compare_manifests_with_fs()[1]:
@@ -215,10 +215,10 @@ def clean_bag(bag_dir):
                 LOGGER.warn("Not removing {}".format(full_path))
 
 
-def make_bag():
+def make_bag(bag_dir, args):
     if is_bag(bag_dir.path):
         LOGGER.warn(_("%s is already a bag. Skipped."), bag_dir.path)
-        continue
+        # continue
 
     if args.no_system_files is True:
         LOGGER.info(_("Cleaning %s of system files"), bag_dir.path)


### PR DESCRIPTION
continue statements were throwing an error because they weren't inside a for or while loop. possible refactor issue? make_bag was missing two args in the method definition that was throwing an error.